### PR TITLE
Add profile context, onboarding UI, roadmap, and Firebase-backed profile storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+EXPO_PUBLIC_FIREBASE_API_KEY=your-firebase-api-key
+EXPO_PUBLIC_FIREBASE_APP_ID=your-firebase-app-id
+EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN=your-project-id.firebaseapp.com
+EXPO_PUBLIC_FIREBASE_DATABASE_URL=https://your-project-id-default-rtdb.firebaseio.com
+EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID=your-firebase-messaging-sender-id
+EXPO_PUBLIC_FIREBASE_PROJECT_ID=your-firebase-project-id
+EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET=your-project-id.firebasestorage.app

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,13 +1,12 @@
-import React from "react";
-import { View } from "react-native";
-import ProfileScreen from "./profile";
+import { Tabs } from 'expo-router';
+import React from 'react';
 
-export default function App() {
-  // In a real app you'd probably render this screen inside a navigator
-  // and pass real user data via props or context.
+export default function TabLayout() {
   return (
-    <View style={{ flex: 1 }}>
-      <ProfileScreen />
-    </View>
+    <Tabs screenOptions={{ headerShown: false }}>
+      <Tabs.Screen name="index" options={{ title: 'Home' }} />
+      <Tabs.Screen name="explore" options={{ title: 'Explore' }} />
+      <Tabs.Screen name="profile" options={{ title: 'Profile' }} />
+    </Tabs>
   );
 }

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,19 +1,18 @@
-import { Picker } from "@react-native-picker/picker";
 import { router } from "expo-router";
 import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
-    Alert,
-    Animated,
-    Platform,
-    SafeAreaView,
-    StyleSheet,
-    Text,
-    TextInput,
-    TouchableOpacity,
-    View,
+  Alert,
+  Animated,
+  SafeAreaView,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  TouchableOpacity,
+  View,
 } from "react-native";
 
-type Knowledge = "Beginner" | "Intermediate" | "Advanced";
+import { CharacterOption, Knowledge, useProfile } from "@/components/profile-context";
 
 const NAVY = "#0F172A";
 const WHITE = "#FFFFFF";
@@ -21,51 +20,35 @@ const GREEN = "#7ED6A5";
 const MUTED = "#CBD5E1";
 const BORDER = "#E2E8F0";
 const SOFT_RED = "#F87171";
+const PANEL = "#F8FAFC";
 
 export default function ProfileSetupScreen() {
-  // Form state
-  const [school, setSchool] = useState<string | null>(null);
-  const [email, setEmail] = useState("");
-  const [firstName, setFirstName] = useState("");
-  const [lastName, setLastName] = useState("");
-  const [age, setAge] = useState("");
-  const [knowledge, setKnowledge] = useState<Knowledge>("Beginner");
+  const { characterOptions, completeProfile, isHydrated, profile, selectedCharacter } = useProfile();
 
-  // Minimal starter list (keep it light for Sprint 0)
-  const schools = useMemo(
-    () => [
-      { label: "Select your school…", value: null },
-      { label: "Westmont College", value: "westmont" },
-      { label: "UCLA", value: "ucla" },
-      { label: "University of Texas at Austin", value: "ut-austin" },
-      { label: "Stanford University", value: "stanford" },
-      { label: "Other (search coming soon)", value: "other" },
-    ],
-    []
-  );
+  const [email, setEmail] = useState(profile?.email ?? "");
+  const [firstName, setFirstName] = useState(profile?.firstName ?? "");
+  const [knowledge, setKnowledge] = useState<Knowledge>(profile?.knowledge ?? "Beginner");
+  const [characterId, setCharacterId] = useState(profile?.characterId ?? "");
+  const [isEditing, setIsEditing] = useState(!profile);
 
-  const emailIsEdu = useMemo(() => {
+  const emailLooksValid = useMemo(() => {
     const trimmed = email.trim().toLowerCase();
-    return /^[^\s@]+@[^\s@]+\.edu$/.test(trimmed);
+    return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trimmed);
   }, [email]);
 
-  // Gating
-  const canEnterEmail = !!school;
-  const canEnterDetails = !!school && emailIsEdu;
+  const canChooseCharacter = firstName.trim().length > 0 && emailLooksValid;
+  const canChooseExperience = canChooseCharacter && characterId !== "";
 
-  // Progress (Step 1–3)
   const currentStep = useMemo(() => {
-    if (!school) return 1;
-    if (!emailIsEdu) return 2;
+    if (!firstName.trim() || !emailLooksValid) return 1;
+    if (!characterId) return 2;
     return 3;
-  }, [school, emailIsEdu]);
+  }, [characterId, emailLooksValid, firstName]);
 
-  // ---------------- Animations ----------------
-  const step1Anim = useRef(new Animated.Value(0)).current; // mount entrance
-  const step2Anim = useRef(new Animated.Value(0)).current; // unlock entrance
-  const step3Anim = useRef(new Animated.Value(0)).current; // unlock entrance
+  const step1Anim = useRef(new Animated.Value(0)).current;
+  const step2Anim = useRef(new Animated.Value(0)).current;
+  const step3Anim = useRef(new Animated.Value(0)).current;
 
-  // Mount: show step 1 nicely
   useEffect(() => {
     Animated.timing(step1Anim, {
       toValue: 1,
@@ -74,9 +57,8 @@ export default function ProfileSetupScreen() {
     }).start();
   }, [step1Anim]);
 
-  // Unlock step 2 when school selected
   useEffect(() => {
-    if (canEnterEmail) {
+    if (canChooseCharacter) {
       Animated.timing(step2Anim, {
         toValue: 1,
         duration: 420,
@@ -85,11 +67,10 @@ export default function ProfileSetupScreen() {
     } else {
       step2Anim.setValue(0);
     }
-  }, [canEnterEmail, step2Anim]);
+  }, [canChooseCharacter, step2Anim]);
 
-  // Unlock step 3 when edu email valid
   useEffect(() => {
-    if (canEnterDetails) {
+    if (canChooseExperience) {
       Animated.timing(step3Anim, {
         toValue: 1,
         duration: 420,
@@ -98,9 +79,8 @@ export default function ProfileSetupScreen() {
     } else {
       step3Anim.setValue(0);
     }
-  }, [canEnterDetails, step3Anim]);
+  }, [canChooseExperience, step3Anim]);
 
-  // Helpers to turn an Animated.Value into “slide up + fade”
   const slideFade = (anim: Animated.Value, yFrom = 10) => ({
     opacity: anim,
     transform: [
@@ -113,154 +93,156 @@ export default function ProfileSetupScreen() {
     ],
   });
 
-function saveProfile() {
-  if (!school) {
-    Alert.alert("Select your school first.");
-    return;
-  }
-  if (!emailIsEdu) {
-    Alert.alert("Please enter a valid .edu email.");
-    return;
-  }
-  if (!firstName.trim() || !lastName.trim()) {
-    Alert.alert("Please enter your first and last name.");
-    return;
+
+  if (!isHydrated) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.loadingState}>
+          <Text style={styles.loadingTitle}>Loading your profile…</Text>
+          <Text style={styles.loadingSubtitle}>Pulling in your saved progress now.</Text>
+        </View>
+      </SafeAreaView>
+    );
   }
 
-  const ageNum = Number(age);
-  if (!age.trim() || Number.isNaN(ageNum)) {
-    Alert.alert("Please enter a valid age.");
-    return;
+  function saveProfile() {
+    if (!firstName.trim()) {
+      Alert.alert("Please add your first name.");
+      return;
+    }
+
+    if (!emailLooksValid) {
+      Alert.alert("Please enter a valid email.");
+      return;
+    }
+
+    if (!characterId) {
+      Alert.alert("Please choose a character.");
+      return;
+    }
+
+    completeProfile({
+      characterId,
+      email: email.trim().toLowerCase(),
+      firstName: firstName.trim(),
+      knowledge,
+    });
+
+    setIsEditing(false);
+    router.replace("/roadmap");
   }
 
-router.replace("/roadmap");
-}
+  if (profile && !isEditing) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <ScrollView contentContainerStyle={styles.contentContainer}>
+          <Text style={styles.title}>Your profile</Text>
+          <Text style={styles.subtitle}>Everything here should help your learning journey feel personal.</Text>
+
+          <View style={styles.summaryCard}>
+            <CharacterBadge character={selectedCharacter} size="large" />
+            <Text style={styles.summaryName}>{profile.firstName}</Text>
+            <Text style={styles.summaryEmail}>{profile.email}</Text>
+            <Text style={styles.summaryMeta}>Starting level: {profile.knowledge}</Text>
+            <TouchableOpacity style={styles.secondaryButton} onPress={() => setIsEditing(true)}>
+              <Text style={styles.secondaryButtonText}>Edit profile</Text>
+            </TouchableOpacity>
+          </View>
+        </ScrollView>
+      </SafeAreaView>
+    );
+  }
 
   return (
     <SafeAreaView style={styles.container}>
-      <Text style={styles.title}>Set up your profile</Text>
-      <Text style={styles.subtitle}>Quick setup, then you’re in.</Text>
+      <ScrollView contentContainerStyle={styles.contentContainer}>
+        <Text style={styles.title}>Set up your profile</Text>
+        <Text style={styles.subtitle}>We only ask for what you’ll actually use as you learn.</Text>
 
-      <ProgressDots currentStep={currentStep} totalSteps={3} />
+        <ProgressDots currentStep={currentStep} totalSteps={3} />
 
-      {/* Step 1 */}
-      <Animated.View style={[styles.card, slideFade(step1Anim, 14)]}>
-        <Text style={styles.stepLabel}>Step 1 of 3</Text>
-        <Text style={styles.sectionTitle}>Select your school</Text>
+        <Animated.View style={[styles.card, slideFade(step1Anim, 14)]}>
+          <Text style={styles.stepLabel}>Step 1 of 3</Text>
+          <Text style={styles.sectionTitle}>Basics you’ll use</Text>
+          <Text style={styles.helper}>Your name personalizes the app, and your email helps identify your account later.</Text>
 
-        <View style={styles.pickerWrapper}>
-          <Picker
-            selectedValue={school}
-            onValueChange={(val) => setSchool(val)}
-            mode={Platform.OS === "ios" ? "dialog" : "dropdown"}
-            style={styles.picker}
-          >
-            {schools.map((s) => (
-              <Picker.Item
-                key={String(s.value)}
-                label={s.label}
-                value={s.value}
-              />
-            ))}
-          </Picker>
-        </View>
-      </Animated.View>
+          <Text style={styles.label}>First name</Text>
+          <TextInput
+            value={firstName}
+            onChangeText={setFirstName}
+            placeholder="What should we call you?"
+            placeholderTextColor="#94A3B8"
+            style={styles.input}
+          />
 
-      {/* Step 2 */}
-      {/* Keep it visible but “locked” until Step 1 done, then animate it in */}
-      <Animated.View
-        style={[
-          styles.card,
-          canEnterEmail ? slideFade(step2Anim, 14) : { opacity: 0.55 },
-        ]}
-      >
-        <Text style={styles.stepLabel}>Step 2 of 3</Text>
-        <Text style={styles.sectionTitle}>School email</Text>
-        <Text style={styles.helper}>
-          Must end in <Text style={styles.bold}>.edu</Text>
-        </Text>
+          <Text style={[styles.label, styles.spacedLabel]}>Email</Text>
+          <TextInput
+            value={email}
+            onChangeText={setEmail}
+            placeholder="you@example.com"
+            placeholderTextColor="#94A3B8"
+            keyboardType="email-address"
+            autoCapitalize="none"
+            style={styles.input}
+          />
 
-        <TextInput
-          value={email}
-          onChangeText={setEmail}
-          placeholder="you@school.edu"
-          placeholderTextColor="#94A3B8"
-          keyboardType="email-address"
-          autoCapitalize="none"
-          style={[styles.input, !canEnterEmail && styles.inputDisabled]}
-          editable={canEnterEmail}
-        />
+          {!!email.trim() && (
+            <Text style={[styles.validation, emailLooksValid ? styles.ok : styles.bad]}>
+              {emailLooksValid ? "Looks good ✅" : "Please use a valid email address"}
+            </Text>
+          )}
+        </Animated.View>
 
-        {!!email.trim() && (
-          <Text style={[styles.validation, emailIsEdu ? styles.ok : styles.bad]}>
-            {emailIsEdu ? "Looks good ✅" : "Needs to end in .edu"}
-          </Text>
-        )}
-      </Animated.View>
+        <Animated.View
+          style={[styles.card, canChooseCharacter ? slideFade(step2Anim, 14) : styles.lockedCard]}
+        >
+          <Text style={styles.stepLabel}>Step 2 of 3</Text>
+          <Text style={styles.sectionTitle}>Pick your character</Text>
+          <Text style={styles.helper}>Inspired by the playful animal-avatar idea you mentioned, this character will follow you on your profile and roadmap.</Text>
 
-      {/* Step 3 */}
-      <Animated.View
-        style={[
-          styles.card,
-          canEnterDetails ? slideFade(step3Anim, 14) : { opacity: 0.55 },
-        ]}
-      >
-        <Text style={styles.stepLabel}>Step 3 of 3</Text>
-        <Text style={styles.sectionTitle}>About you</Text>
+          <View style={styles.characterGrid}>
+            {characterOptions.map((character) => {
+              const selected = character.id === characterId;
 
-        <View style={styles.row}>
-          <View style={styles.half}>
-            <Text style={styles.label}>First name</Text>
-            <TextInput
-              value={firstName}
-              onChangeText={setFirstName}
-              placeholder="First"
-              placeholderTextColor="#94A3B8"
-              style={[styles.input, !canEnterDetails && styles.inputDisabled]}
-              editable={canEnterDetails}
-            />
+              return (
+                <TouchableOpacity
+                  key={character.id}
+                  onPress={() => setCharacterId(character.id)}
+                  disabled={!canChooseCharacter}
+                  style={[
+                    styles.characterCard,
+                    { borderColor: selected ? character.accent : BORDER },
+                    selected && { backgroundColor: `${character.accent}18` },
+                    !canChooseCharacter && styles.buttonDisabled,
+                  ]}
+                >
+                  <CharacterBadge character={character} size="small" />
+                  <Text style={styles.characterLabel}>{character.label}</Text>
+                </TouchableOpacity>
+              );
+            })}
           </View>
+        </Animated.View>
 
-          <View style={styles.half}>
-            <Text style={styles.label}>Last name</Text>
-            <TextInput
-              value={lastName}
-              onChangeText={setLastName}
-              placeholder="Last"
-              placeholderTextColor="#94A3B8"
-              style={[styles.input, !canEnterDetails && styles.inputDisabled]}
-              editable={canEnterDetails}
-            />
-          </View>
-        </View>
+        <Animated.View
+          style={[styles.card, canChooseExperience ? slideFade(step3Anim, 14) : styles.lockedCard]}
+        >
+          <Text style={styles.stepLabel}>Step 3 of 3</Text>
+          <Text style={styles.sectionTitle}>Where are you starting?</Text>
+          <Text style={styles.helper}>This helps us pace the roadmap and lessons appropriately.</Text>
 
-        <Text style={[styles.label, { marginTop: 10 }]}>Age</Text>
-        <TextInput
-          value={age}
-          onChangeText={setAge}
-          placeholder="e.g., 21"
-          placeholderTextColor="#94A3B8"
-          keyboardType="number-pad"
-          style={[styles.input, !canEnterDetails && styles.inputDisabled]}
-          editable={canEnterDetails}
-        />
-
-        <Text style={[styles.label, { marginTop: 12 }]}>
-          Previous knowledge
-        </Text>
-        <View style={styles.knowledgeRow}>
-          {(["Beginner", "Intermediate", "Advanced"] as Knowledge[]).map(
-            (level) => {
+          <View style={styles.knowledgeRow}>
+            {(["Beginner", "Intermediate", "Advanced"] as Knowledge[]).map((level) => {
               const selected = knowledge === level;
               return (
                 <TouchableOpacity
                   key={level}
                   onPress={() => setKnowledge(level)}
-                  disabled={!canEnterDetails}
+                  disabled={!canChooseExperience}
                   style={[
                     styles.knowledgeButton,
                     selected && styles.knowledgeButtonSelected,
-                    !canEnterDetails && styles.buttonDisabled,
+                    !canChooseExperience && styles.buttonDisabled,
                   ]}
                 >
                   <Text
@@ -273,19 +255,49 @@ router.replace("/roadmap");
                   </Text>
                 </TouchableOpacity>
               );
-            }
-          )}
-        </View>
+            })}
+          </View>
 
-        <TouchableOpacity
-          style={[styles.saveButton, !canEnterDetails && styles.buttonDisabled]}
-          onPress={saveProfile}
-          disabled={!canEnterDetails}
-        >
-          <Text style={styles.saveButtonText}>Save profile</Text>
-        </TouchableOpacity>
-      </Animated.View>
+          <TouchableOpacity
+            style={[styles.saveButton, !canChooseExperience && styles.buttonDisabled]}
+            onPress={saveProfile}
+            disabled={!canChooseExperience}
+          >
+            <Text style={styles.saveButtonText}>Save profile</Text>
+          </TouchableOpacity>
+        </Animated.View>
+      </ScrollView>
     </SafeAreaView>
+  );
+}
+
+function CharacterBadge({
+  character,
+  size,
+}: {
+  character: CharacterOption | null;
+  size: "small" | "large";
+}) {
+  if (!character) {
+    return null;
+  }
+
+  const badgeSize = size === "large" ? 96 : 64;
+  const fontSize = size === "large" ? 42 : 28;
+
+  return (
+    <View
+      style={[
+        styles.characterBadge,
+        {
+          backgroundColor: character.accent,
+          height: badgeSize,
+          width: badgeSize,
+        },
+      ]}
+    >
+      <Text style={[styles.characterEmoji, { fontSize }]}>{character.emoji}</Text>
+    </View>
   );
 }
 
@@ -322,7 +334,10 @@ const styles = StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: NAVY,
+  },
+  contentContainer: {
     padding: 20,
+    gap: 14,
   },
   title: {
     fontSize: 28,
@@ -336,11 +351,10 @@ const styles = StyleSheet.create({
     fontSize: 14,
     lineHeight: 18,
   },
-
   dotsRow: {
     flexDirection: "row",
     gap: 8,
-    marginBottom: 16,
+    marginBottom: 2,
   },
   dot: {
     width: 10,
@@ -354,60 +368,42 @@ const styles = StyleSheet.create({
   dotComplete: {
     backgroundColor: "rgba(126,214,165,0.6)",
   },
-
   card: {
     backgroundColor: WHITE,
     borderRadius: 14,
     padding: 16,
     marginBottom: 14,
-    shadowColor: "#000",
-    shadowOpacity: 0.12,
-    shadowRadius: 10,
-    shadowOffset: { width: 0, height: 4 },
-    elevation: 3,
+    boxShadow: "0px 4px 18px rgba(15, 23, 42, 0.12)",
+    gap: 10,
   },
-
+  lockedCard: {
+    opacity: 0.55,
+  },
   stepLabel: {
     fontSize: 12,
     fontWeight: "900",
     color: GREEN,
-    marginBottom: 6,
     letterSpacing: 0.6,
     textTransform: "uppercase",
   },
   sectionTitle: {
-    fontSize: 16,
+    fontSize: 18,
     fontWeight: "800",
     color: NAVY,
-    marginBottom: 8,
   },
   helper: {
     fontSize: 13,
     color: "#64748B",
-    marginBottom: 8,
+    lineHeight: 18,
   },
-  bold: {
-    fontWeight: "900",
-    color: NAVY,
-  },
-
-  pickerWrapper: {
-    borderWidth: 1,
-    borderColor: BORDER,
-    borderRadius: 10,
-    overflow: "hidden",
-    backgroundColor: WHITE,
-  },
-  picker: {
-    height: 48,
-    width: "100%",
-  },
-
   label: {
     fontSize: 13,
     fontWeight: "700",
     color: "#334155",
     marginBottom: 6,
+  },
+  spacedLabel: {
+    marginTop: 8,
   },
   input: {
     borderWidth: 1,
@@ -419,12 +415,7 @@ const styles = StyleSheet.create({
     fontSize: 14,
     color: NAVY,
   },
-  inputDisabled: {
-    backgroundColor: "#F1F5F9",
-  },
-
   validation: {
-    marginTop: 8,
     fontSize: 13,
     fontWeight: "700",
   },
@@ -434,20 +425,38 @@ const styles = StyleSheet.create({
   bad: {
     color: SOFT_RED,
   },
-
-  row: {
+  characterGrid: {
     flexDirection: "row",
+    flexWrap: "wrap",
     gap: 12,
   },
-  half: {
-    flex: 1,
+  characterCard: {
+    width: "47%",
+    borderWidth: 1,
+    borderRadius: 14,
+    padding: 12,
+    backgroundColor: PANEL,
+    alignItems: "center",
+    gap: 10,
   },
-
+  characterBadge: {
+    borderRadius: 999,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  characterEmoji: {
+    textAlign: "center",
+  },
+  characterLabel: {
+    color: NAVY,
+    fontSize: 14,
+    fontWeight: "800",
+  },
   knowledgeRow: {
     flexDirection: "row",
     gap: 8,
     marginTop: 6,
-    marginBottom: 14,
+    marginBottom: 8,
   },
   knowledgeButton: {
     flex: 1,
@@ -466,7 +475,6 @@ const styles = StyleSheet.create({
   knowledgeTextSelected: {
     color: WHITE,
   },
-
   saveButton: {
     backgroundColor: NAVY,
     paddingVertical: 12,
@@ -478,7 +486,57 @@ const styles = StyleSheet.create({
     fontWeight: "900",
     fontSize: 16,
   },
+  secondaryButton: {
+    marginTop: 8,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: BORDER,
+    paddingVertical: 12,
+    paddingHorizontal: 18,
+  },
+  secondaryButtonText: {
+    color: NAVY,
+    fontWeight: "800",
+  },
   buttonDisabled: {
     opacity: 0.5,
+  },
+  loadingState: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 24,
+    gap: 8,
+  },
+  loadingTitle: {
+    color: WHITE,
+    fontSize: 22,
+    fontWeight: "800",
+  },
+  loadingSubtitle: {
+    color: MUTED,
+    fontSize: 14,
+    textAlign: "center",
+  },
+  summaryCard: {
+    backgroundColor: WHITE,
+    borderRadius: 18,
+    padding: 20,
+    alignItems: "center",
+    gap: 10,
+  },
+  summaryName: {
+    color: NAVY,
+    fontSize: 24,
+    fontWeight: "900",
+  },
+  summaryEmail: {
+    color: "#475569",
+    fontSize: 14,
+  },
+  summaryMeta: {
+    color: "#64748B",
+    fontSize: 14,
+    fontWeight: "700",
   },
 });

--- a/app/Splash.tsx
+++ b/app/Splash.tsx
@@ -8,7 +8,7 @@ const TAGLINE = "learn it gently";
 const INVEST_SPEED = 220;   // slower typing for "invest"
 const ISH_SPEED = 240;      // even slower for "-ish" (feels deliberate)
 const TAGLINE_SPEED = 120;  // gentle, readable tagline
-const PAUSE_BEFORE_ISH = 1500; // 1 full second dramatic pause
+const PAUSE_BEFORE_ISH = 1500; // dramatic pause before finishing the title
 
 const PAUSE_BEFORE_TAGLINE = 500;
 const SPLASH_TOTAL_TIME = 10000;
@@ -86,7 +86,7 @@ export default function Splash({ onDone }: { onDone: () => void }) {
   useEffect(() => {
     const done = setTimeout(onDone, SPLASH_TOTAL_TIME);
     return () => clearTimeout(done);
-  }, []);
+  }, [onDone]);
 
   return (
     <View style={styles.container}>

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -3,6 +3,7 @@ import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
 import 'react-native-reanimated';
 
+import { ProfileProvider } from '@/components/profile-context';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 
 export const unstable_settings = {
@@ -14,11 +15,15 @@ export default function RootLayout() {
 
   return (
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
-      </Stack>
-      <StatusBar style="auto" />
+      <ProfileProvider>
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="roadmap" options={{ title: 'Roadmap' }} />
+          <Stack.Screen name="lesson-1" options={{ title: 'Lesson 1' }} />
+          <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
+        </Stack>
+        <StatusBar style="auto" />
+      </ProfileProvider>
     </ThemeProvider>
   );
 }

--- a/app/roadmap.tsx
+++ b/app/roadmap.tsx
@@ -1,0 +1,270 @@
+import { router } from "expo-router";
+import React from "react";
+import { SafeAreaView, ScrollView, StyleSheet, Text, TouchableOpacity, View } from "react-native";
+
+import { useProfile } from "@/components/profile-context";
+
+const NAVY = "#0F172A";
+const WHITE = "#FFFFFF";
+const MUTED = "#CBD5E1";
+const PANEL = "#F8FAFC";
+
+type Module = {
+  description: string;
+  id: string;
+  status: "Current" | "Locked";
+  title: string;
+};
+
+const MODULES: Module[] = [
+  {
+    id: "lesson-1",
+    title: "Module 1: The calm intro",
+    description: "A short warm-up to get comfortable before we go deeper.",
+    status: "Current",
+  },
+  {
+    id: "coming-soon",
+    title: "Module 2: Your first strategy",
+    description: "Coming next: a practical lesson you can use immediately.",
+    status: "Locked",
+  },
+];
+
+function RoadmapScreen() {
+  const { isHydrated, profile, selectedCharacter } = useProfile();
+
+
+  if (!isHydrated) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.loadingState}>
+          <Text style={styles.loadingTitle}>Loading roadmap…</Text>
+          <Text style={styles.loadingSubtitle}>Syncing your saved profile and progress.</Text>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  return (
+    <SafeAreaView style={styles.container}>
+      <ScrollView contentContainerStyle={styles.content}>
+        <Text style={styles.title}>Your learning roadmap</Text>
+        <Text style={styles.subtitle}>Follow your character to see exactly where you are right now.</Text>
+
+        <View style={styles.heroCard}>
+          <View style={[styles.avatarShell, { backgroundColor: selectedCharacter?.accent ?? "#1E293B" }]}>
+            <Text style={styles.avatarEmoji}>{selectedCharacter?.emoji ?? "✨"}</Text>
+          </View>
+
+          <View style={styles.heroCopy}>
+            <Text style={styles.heroTitle}>
+              {profile ? `${profile.firstName}, you’re on Module 1.` : "You’re ready to start Module 1."}
+            </Text>
+            <Text style={styles.heroText}>
+              {profile
+                ? `${selectedCharacter?.label ?? "Your character"} will follow your progress as you move through the roadmap.`
+                : "Finish your profile to personalize this roadmap."}
+            </Text>
+          </View>
+        </View>
+
+        {MODULES.map((module) => {
+          const isCurrent = module.id === profile?.currentModuleId || (!profile && module.id === "lesson-1");
+          const isReady = module.id === "lesson-1";
+
+          return (
+            <View key={module.id} style={styles.card}>
+              <View style={styles.cardHeader}>
+                <Text style={styles.cardTitle}>{module.title}</Text>
+                <Text style={[styles.badge, isCurrent ? styles.badgeCurrent : styles.badgeLocked]}>
+                  {module.status}
+                </Text>
+              </View>
+
+              <Text style={styles.cardDescription}>{module.description}</Text>
+
+              {isCurrent && selectedCharacter ? (
+                <View style={styles.youAreHereRow}>
+                  <View style={[styles.inlineAvatar, { backgroundColor: selectedCharacter.accent }]}>
+                    <Text style={styles.inlineAvatarEmoji}>{selectedCharacter.emoji}</Text>
+                  </View>
+                  <Text style={styles.youAreHereText}>You are here</Text>
+                </View>
+              ) : null}
+
+              {isReady ? (
+                <TouchableOpacity
+                  accessibilityRole="button"
+                  style={styles.button}
+                  onPress={() => router.push("/lesson-1")}
+                >
+                  <Text style={styles.buttonText}>Start module</Text>
+                </TouchableOpacity>
+              ) : (
+                <View style={styles.lockedButton}>
+                  <Text style={styles.lockedButtonText}>Unlock by finishing Module 1</Text>
+                </View>
+              )}
+            </View>
+          );
+        })}
+      </ScrollView>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: NAVY,
+  },
+  content: {
+    padding: 20,
+    gap: 14,
+  },
+  title: {
+    color: WHITE,
+    fontSize: 28,
+    fontWeight: "900",
+  },
+  subtitle: {
+    color: MUTED,
+    fontSize: 14,
+    marginTop: 4,
+    marginBottom: 8,
+  },
+  loadingState: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
+    paddingHorizontal: 24,
+    gap: 8,
+  },
+  loadingTitle: {
+    color: WHITE,
+    fontSize: 22,
+    fontWeight: "800",
+  },
+  loadingSubtitle: {
+    color: MUTED,
+    fontSize: 14,
+    textAlign: "center",
+  },
+  heroCard: {
+    backgroundColor: WHITE,
+    borderRadius: 18,
+    padding: 18,
+    flexDirection: "row",
+    gap: 14,
+    alignItems: "center",
+  },
+  avatarShell: {
+    width: 72,
+    height: 72,
+    borderRadius: 999,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  avatarEmoji: {
+    fontSize: 34,
+  },
+  heroCopy: {
+    flex: 1,
+    gap: 4,
+  },
+  heroTitle: {
+    color: NAVY,
+    fontSize: 18,
+    fontWeight: "900",
+  },
+  heroText: {
+    color: "#475569",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  card: {
+    backgroundColor: WHITE,
+    borderRadius: 14,
+    padding: 14,
+    gap: 10,
+  },
+  cardHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    gap: 8,
+  },
+  cardTitle: {
+    color: NAVY,
+    fontSize: 17,
+    fontWeight: "800",
+    flex: 1,
+  },
+  badge: {
+    borderRadius: 999,
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+    fontSize: 12,
+    fontWeight: "800",
+    overflow: "hidden",
+  },
+  badgeCurrent: {
+    color: "#065F46",
+    backgroundColor: "#D1FAE5",
+  },
+  badgeLocked: {
+    color: "#6B7280",
+    backgroundColor: "#E5E7EB",
+  },
+  cardDescription: {
+    color: "#334155",
+    fontSize: 14,
+    lineHeight: 20,
+  },
+  youAreHereRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+    padding: 10,
+    borderRadius: 12,
+    backgroundColor: PANEL,
+  },
+  inlineAvatar: {
+    width: 38,
+    height: 38,
+    borderRadius: 999,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  inlineAvatarEmoji: {
+    fontSize: 18,
+  },
+  youAreHereText: {
+    color: NAVY,
+    fontSize: 14,
+    fontWeight: "800",
+  },
+  button: {
+    backgroundColor: NAVY,
+    borderRadius: 10,
+    paddingVertical: 10,
+    alignItems: "center",
+  },
+  buttonText: {
+    color: WHITE,
+    fontWeight: "900",
+  },
+  lockedButton: {
+    borderRadius: 10,
+    paddingVertical: 10,
+    alignItems: "center",
+    backgroundColor: "#F1F5F9",
+  },
+  lockedButtonText: {
+    color: "#64748B",
+    fontWeight: "700",
+  },
+});
+
+export default RoadmapScreen;

--- a/components/profile-context.tsx
+++ b/components/profile-context.tsx
@@ -1,0 +1,98 @@
+import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+
+import { loadStoredProfile, saveStoredProfile } from "@/lib/profile-storage";
+
+export type Knowledge = "Beginner" | "Intermediate" | "Advanced";
+
+export type CharacterOption = {
+  accent: string;
+  emoji: string;
+  id: string;
+  label: string;
+};
+
+export type ProfileData = {
+  characterId: string;
+  currentModuleId: string;
+  email: string;
+  firstName: string;
+  knowledge: Knowledge;
+};
+
+type ProfileContextValue = {
+  characterOptions: CharacterOption[];
+  completeProfile: (profile: Omit<ProfileData, "currentModuleId">) => void;
+  isHydrated: boolean;
+  profile: ProfileData | null;
+  selectedCharacter: CharacterOption | null;
+};
+
+const CHARACTER_OPTIONS: CharacterOption[] = [
+  { id: "alligator", label: "Alligator", emoji: "🐊", accent: "#34D399" },
+  { id: "dolphin", label: "Dolphin", emoji: "🐬", accent: "#60A5FA" },
+  { id: "elephant", label: "Elephant", emoji: "🐘", accent: "#A78BFA" },
+  { id: "fox", label: "Fox", emoji: "🦊", accent: "#FB923C" },
+  { id: "koala", label: "Koala", emoji: "🐨", accent: "#94A3B8" },
+  { id: "penguin", label: "Penguin", emoji: "🐧", accent: "#F472B6" },
+];
+
+const ProfileContext = createContext<ProfileContextValue | undefined>(undefined);
+
+export function ProfileProvider({ children }: { children: React.ReactNode }) {
+  const [profile, setProfile] = useState<ProfileData | null>(null);
+  const [isHydrated, setIsHydrated] = useState(false);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    async function hydrateProfile() {
+      const storedProfile = await loadStoredProfile();
+
+      if (!isMounted) {
+        return;
+      }
+
+      setProfile(storedProfile);
+      setIsHydrated(true);
+    }
+
+    void hydrateProfile();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const value = useMemo<ProfileContextValue>(() => {
+    const selectedCharacter =
+      CHARACTER_OPTIONS.find((character) => character.id === profile?.characterId) ?? null;
+
+    return {
+      characterOptions: CHARACTER_OPTIONS,
+      completeProfile: (nextProfile) => {
+        const completeData: ProfileData = {
+          ...nextProfile,
+          currentModuleId: "lesson-1",
+        };
+
+        setProfile(completeData);
+        void saveStoredProfile(completeData);
+      },
+      isHydrated,
+      profile,
+      selectedCharacter,
+    };
+  }, [isHydrated, profile]);
+
+  return <ProfileContext.Provider value={value}>{children}</ProfileContext.Provider>;
+}
+
+export function useProfile() {
+  const context = useContext(ProfileContext);
+
+  if (!context) {
+    throw new Error("useProfile must be used inside ProfileProvider");
+  }
+
+  return context;
+}

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,0 +1,60 @@
+import { FirebaseApp, getApp, getApps, initializeApp } from "firebase/app";
+import { Database, getDatabase } from "firebase/database";
+
+type FirebaseConfig = {
+  apiKey: string;
+  appId: string;
+  authDomain?: string;
+  databaseURL: string;
+  messagingSenderId: string;
+  projectId: string;
+  storageBucket?: string;
+};
+
+function readEnv(name: string) {
+  return process.env[name]?.trim() ?? "";
+}
+
+const firebaseConfig: FirebaseConfig = {
+  apiKey: readEnv("EXPO_PUBLIC_FIREBASE_API_KEY"),
+  appId: readEnv("EXPO_PUBLIC_FIREBASE_APP_ID"),
+  authDomain: readEnv("EXPO_PUBLIC_FIREBASE_AUTH_DOMAIN") || undefined,
+  databaseURL: readEnv("EXPO_PUBLIC_FIREBASE_DATABASE_URL"),
+  messagingSenderId: readEnv("EXPO_PUBLIC_FIREBASE_MESSAGING_SENDER_ID"),
+  projectId: readEnv("EXPO_PUBLIC_FIREBASE_PROJECT_ID"),
+  storageBucket: readEnv("EXPO_PUBLIC_FIREBASE_STORAGE_BUCKET") || undefined,
+};
+
+const requiredConfigKeys: Array<keyof FirebaseConfig> = [
+  "apiKey",
+  "appId",
+  "databaseURL",
+  "messagingSenderId",
+  "projectId",
+];
+
+export function isFirebaseConfigured() {
+  return requiredConfigKeys.every((key) => Boolean(firebaseConfig[key]));
+}
+
+function getFirebaseApp(): FirebaseApp | null {
+  if (!isFirebaseConfigured()) {
+    return null;
+  }
+
+  if (getApps().length > 0) {
+    return getApp();
+  }
+
+  return initializeApp(firebaseConfig);
+}
+
+export function getFirebaseDatabase(): Database | null {
+  const app = getFirebaseApp();
+
+  if (!app) {
+    return null;
+  }
+
+  return getDatabase(app);
+}

--- a/lib/profile-storage.ts
+++ b/lib/profile-storage.ts
@@ -1,0 +1,85 @@
+import { get, ref, set } from "firebase/database";
+
+import { ProfileData } from "@/components/profile-context";
+import { getFirebaseDatabase } from "@/lib/firebase";
+
+const STORAGE_KEY = "investish.profile";
+
+function canUseLocalStorage() {
+  return typeof window !== "undefined" && typeof window.localStorage !== "undefined";
+}
+
+function getProfileKey(email: string) {
+  return email.trim().toLowerCase().replace(/[.#$\[\]/]/g, "_");
+}
+
+function parseProfile(value: string | null): ProfileData | null {
+  if (!value) {
+    return null;
+  }
+
+  try {
+    return JSON.parse(value) as ProfileData;
+  } catch {
+    return null;
+  }
+}
+
+function loadLocalProfile() {
+  if (!canUseLocalStorage()) {
+    return null;
+  }
+
+  return parseProfile(window.localStorage.getItem(STORAGE_KEY));
+}
+
+function saveLocalProfile(profile: ProfileData) {
+  if (!canUseLocalStorage()) {
+    return;
+  }
+
+  window.localStorage.setItem(STORAGE_KEY, JSON.stringify(profile));
+}
+
+export async function loadStoredProfile() {
+  const localProfile = loadLocalProfile();
+  const database = getFirebaseDatabase();
+
+  if (!localProfile || !database) {
+    return localProfile;
+  }
+
+  try {
+    const snapshot = await get(ref(database, `profiles/${getProfileKey(localProfile.email)}`));
+
+    if (!snapshot.exists()) {
+      return localProfile;
+    }
+
+    const remoteProfile = snapshot.val() as ProfileData | null;
+
+    if (remoteProfile) {
+      saveLocalProfile(remoteProfile);
+    }
+
+    return remoteProfile ?? localProfile;
+  } catch {
+    return localProfile;
+  }
+}
+
+export async function saveStoredProfile(profile: ProfileData) {
+  saveLocalProfile(profile);
+
+  const database = getFirebaseDatabase();
+
+  if (!database) {
+    return;
+  }
+
+  try {
+    await set(ref(database, `profiles/${getProfileKey(profile.email)}`), profile);
+  } catch {
+    // Keep local persistence working even if remote sync fails.
+  }
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-web": "~0.21.0",
-    "react-native-worklets": "0.5.1"
+    "react-native-worklets": "0.5.1",
+    "firebase": "^12.0.0"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",


### PR DESCRIPTION
### Motivation

- Centralize profile state and persistence so onboarding and roadmap screens can share a single source of truth and hydrate saved progress.  
- Replace the old single-screen profile flow with a guided, 3-step onboarding that selects a character, name, email and starting knowledge to personalize the app.  
- Prepare optional remote sync via Firebase and surface configuration via an `.env.example` to enable cloud-backed profile storage.

### Description

- Introduces a `ProfileProvider` and `useProfile` in `components/profile-context.tsx` to expose `characterOptions`, `completeProfile`, `isHydrated`, `profile`, and `selectedCharacter`.  
- Adds local+remote persistence helpers in `lib/profile-storage.ts` that sync to Firebase when configured and new `lib/firebase.ts` that initializes the SDK and exposes `getFirebaseDatabase`.  
- Refactors `app/(tabs)/profile.tsx` to consume the profile context, implement a 3-step onboarding UI (name, email, character, knowledge), show a profile summary when complete, and replace older school/.edu gating.  
- Adds a `roadmap` screen at `app/roadmap.tsx` that uses the profile state to personalize content and navigate to `lesson-1`.  
- Updates navigation/layouts: new tab layout `app/(tabs)/_layout.tsx` using `Tabs`, and wraps the root layout in `ProfileProvider` in `app/_layout.tsx`; also adds some stack routes.  
- Adds `app/Splash.tsx` minor adjustments and creates `.env.example` with Firebase keys.  
- Adds `firebase` dependency in `package.json` and wires remote persistence to run when Firebase env vars are provided.

### Testing

- No automated tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698c1695bf0083209fdbc88224ee6704)